### PR TITLE
Fix bug when searching for domain using multiple keywords

### DIFF
--- a/clouddns/connection.py
+++ b/clouddns/connection.py
@@ -209,7 +209,7 @@ class Connection(object):
         if 'name' in dico:
             dico['name'] = dico['name'].lower()
 
-        domains = self.list_domains_info(name=dico.get('name', None))
+        domains = self.list_domains_info(name=dico.get('name', None), limit=1)
         for domain in domains:
             if is_subdict(dico, domain):
                 return Domain(self, **domain)

--- a/clouddns/connection.py
+++ b/clouddns/connection.py
@@ -21,7 +21,7 @@ from math import ceil
 from sys import version_info
 from urllib import quote
 
-from utils  import unicode_quote, parse_url, \
+from utils  import unicode_quote, parse_url, is_subdict, \
     THTTPConnection, THTTPSConnection
 from domain import DomainResults, Domain
 from authentication import Authentication
@@ -211,9 +211,8 @@ class Connection(object):
 
         domains = self.list_domains_info(name=dico.get('name', None))
         for domain in domains:
-            for k in dico:
-                if k in domain and domain[k] == dico[k]:
-                    return Domain(self, **domain)
+            if is_subdict(dico, domain):
+                return Domain(self, **domain)
         raise UnknownDomain("Not found")
 
     def get_domain_details(self, id=None):

--- a/clouddns/domain.py
+++ b/clouddns/domain.py
@@ -6,6 +6,7 @@ import consts
 from errors import InvalidDomainName, ResponseError
 from math import ceil
 from record import RecordResults, Record
+from utils import is_subdict
 
 
 class Domain(object):
@@ -61,9 +62,8 @@ class Domain(object):
             dico['name'] = dico['name'].lower()
         records = self.list_records_info()
         for record in records:
-            for k in dico:
-                if k in record and record[k] == dico[k]:
-                    return Record(self, **record)
+            if is_subdict(dico, record):
+                return Record(self, **record)
         #TODO:
         raise Exception("Not found")
 

--- a/clouddns/utils.py
+++ b/clouddns/utils.py
@@ -49,6 +49,19 @@ def unicode_quote(s):
     else:
         return quote(str(s))
 
+def is_subdict(subdict, parentdict):
+    """
+    Utility function that returns True id `subdict` is a subset
+    of `parentdict`.
+    All the key->value pairs found in `subdict` should be found
+    and equal in `parentdict`
+    """
+    for key in subdict:
+        if key not in parentdict:
+            return False
+        if subdict[key] != parentdict[key]:
+            return False
+    return True
 
 class THTTPConnection(HTTPConnection):
     def __init__(self, host, port, timeout):

--- a/tests/t.py
+++ b/tests/t.py
@@ -86,26 +86,37 @@ def test():
     # Update Domain
     domain.update(ttl=ttl)
 
-    record = "test1.%s" % (DOMAIN)
+    record1 = "test1.%s" % (DOMAIN)
+    record2 = "test2.%s" % (DOMAIN)
     # Create Record
-    dbg("Creating Record: %s" % (record))
-    newRecord = \
-        domain.create_record(record, "127.0.0.1", "A")
+    dbg("Creating Record: %s" % (record1))
+    newRecord1 = \
+        domain.create_record(record1, "127.0.0.1", "A")
+    dbg("Creating Record: %s" % (record2))
+    newRecord2 = \
+        domain.create_record(record2, "127.0.0.2", "A")
 
     # Get Record by ID
-    dbg("Get Record By ID: %s" % (newRecord.id))
-    record = domain.get_record(newRecord.id)
-    assert(record.id == newRecord.id)
+    dbg("Get Record By ID: %s" % (newRecord1.id))
+    record = domain.get_record(newRecord1.id)
+    assert(record.id == newRecord1.id)
 
     # Get Record by name
-    dbg("Get Record By Name: %s" % (record))
+    dbg("Get Record By Name: %s" % (record1))
     record = domain.get_record(name=record.name)
-    assert(record.id == newRecord.id)
+    assert(record.id == newRecord1.id)
+
+    # Get Record by name and data
+    dbg("Get Record By Type And Name: %s" % (newRecord2))
+    record = domain.get_record(type=newRecord2.type,
+                               name=newRecord2.name)
+    assert(record.id == newRecord2.id)
 
     # Modify Record data
-    newRecord.update(data="127.0.0.2", ttl=1300)
+    newRecord1.update(data="127.0.1.1", ttl=1300)
 
-    # Delete Record
-    domain.delete_record(newRecord.id)
+    # Delete Records
+    domain.delete_record(newRecord1.id)
+    domain.delete_record(newRecord2.id)
 
 test()


### PR DESCRIPTION
`Domain.get_record()` was using a weak dict comparison that returns "true" as soon as a key->value matches.

So if I had two records like:
- `type='CNAME'`, `name='demo.site.com'`
- `type='CNAME'`, `name='sample.site.com'`

and search for `domain.get_record(type='CNAME', name='sample.site.com')` it could return the first record, because `'type'` key would match.

Also, since it's a dict, this error could become inconsistent because dict keys have no order (if it searched for `'name'` key before `'type'` in this case, would work fine)

Note that I've created a small function `is_subdict()` to handle it, and used on `Connection.get_domain()` because I found the same loop. Just for consistency.
