### PR TITLE
docs: Fix a few typos

### DIFF
--- a/clouddns/authentication.py
+++ b/clouddns/authentication.py
@@ -2,7 +2,7 @@
 authentication operations
 
 Authentication instances are used to interact with the remote
-authentication service, retreiving storage system routing information
+authentication service, retrieving storage system routing information
 and session tokens.
 
 See COPYING for license information.

--- a/clouddns/connection.py
+++ b/clouddns/connection.py
@@ -229,7 +229,7 @@ class Connection(object):
 
         return Domain(self, **domains)
 
-    # Take a reponse parse it if there is asyncResponse and wait for
+    # Take a response parse it if there is asyncResponse and wait for
     # it (TODO: should offer to not)
     def wait_for_async_request(self, response):
         if (response.status < 200) or (response.status > 299):


### PR DESCRIPTION
There are small typos in:
- clouddns/authentication.py
- clouddns/connection.py

Fixes:
- Should read `retrieving` rather than `retreiving`.
- Should read `response` rather than `reponse`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md